### PR TITLE
잘못 구현된 LiP 고장 모델 수정 (#21)

### DIFF
--- a/faults/faults.py
+++ b/faults/faults.py
@@ -91,11 +91,13 @@ class LiP(Fault):
 
     def get(self, t, u):
         if abs(t - self.time) < 0.5*self.dt:  # consider errors e.g. machine precision
-            self.u_locked = u
-        if self.u_locked is None:
-            return u
+            self.u_locked = u[self.index]
+        if t > self.time + 0.5*self.dt:  # after LiP occurs
+            u_fault = deepcopy(u)
+            u_fault[self.index] = self.u_locked
+            return u_fault
         else:
-            return self.u_locked
+            return u
 
 
 # """

--- a/faults/faults.py
+++ b/faults/faults.py
@@ -148,7 +148,7 @@ if __name__ == "__main__":
         fault = LiP(2, 0, 0.1)
         print(fault.get(1.9, [3, 0]))  # 3
         print(fault.get(1.95, [4, 1]))  # 4
-        print(fault.get(2.05, [5, 2]))  # 4
+        print(fault.get(2.05, [5, 2]))  # 4.5
         print(fault.get(1.96, [6, 3]))  # 6
-        print(fault.get(2.06, [7, 4]))  # 4
+        print(fault.get(2.06, [7, 4]))  # 4.5
     small_test()


### PR DESCRIPTION
(Fix #21)
LiP 가 잘못 구현되어있어, 다시 구현함.

### 테스트 결과
Note: 제어입력은 `t * np.ones(n)` where `t`: time, `n`: constant 형태로 줌
```
Fault name: LoE
time = 2, index = 1, level = 0.1
Actuator command: [0. 0. 0. 0. 0. 0.], time: 0
Actual input: [0. 0. 0. 0. 0. 0.]
Actuator command: [1.99 1.99 1.99 1.99 1.99 1.99], time: 1.99
Actual input: [1.99 1.99 1.99 1.99 1.99 1.99]
Actuator command: [2. 2. 2. 2. 2. 2.], time: 2.0
Actual input: [2.  0.2 2.  2.  2.  2. ]
Actuator command: [2.01 2.01 2.01 2.01 2.01 2.01], time: 2.01
Actual input: [2.01  0.201 2.01  2.01  2.01  2.01 ]
Actuator command: [10. 10. 10. 10. 10. 10.], time: 10
Actual input: [10.  1. 10. 10. 10. 10.]
Fault name: Float
time = 2, index = 1, level = 0.0
Actuator command: [0. 0. 0. 0. 0. 0.], time: 0
Actual input: [0. 0. 0. 0. 0. 0.]
Actuator command: [1.99 1.99 1.99 1.99 1.99 1.99], time: 1.99
Actual input: [1.99 1.99 1.99 1.99 1.99 1.99]
Actuator command: [2. 2. 2. 2. 2. 2.], time: 2.0
Actual input: [2. 0. 2. 2. 2. 2.]
Actuator command: [2.01 2.01 2.01 2.01 2.01 2.01], time: 2.01
Actual input: [2.01 0.   2.01 2.01 2.01 2.01]
Actuator command: [10. 10. 10. 10. 10. 10.], time: 10
Actual input: [10.  0. 10. 10. 10. 10.]
Fault name: LiP
time = 2, index = 1, dt = 0.01
Actuator command: [0. 0. 0. 0. 0. 0.], time: 0
Actual input: [0. 0. 0. 0. 0. 0.]
Actuator command: [1.99 1.99 1.99 1.99 1.99 1.99], time: 1.99
Actual input: [1.99 1.99 1.99 1.99 1.99 1.99]
Actuator command: [2. 2. 2. 2. 2. 2.], time: 2.0
Actual input: [2. 2. 2. 2. 2. 2.]
Actuator command: [2.01 2.01 2.01 2.01 2.01 2.01], time: 2.01
Actual input: [2. 2. 2. 2. 2. 2.]
Actuator command: [10. 10. 10. 10. 10. 10.], time: 10
Actual input: [2. 2. 2. 2. 2. 2.]

```