### PR TITLE
Add direct backstepping controller

### DIFF
--- a/ftc/agents/backstepping.py
+++ b/ftc/agents/backstepping.py
@@ -70,6 +70,21 @@ class BacksteppingController(BaseEnv):
         ])
         self.P = solve_lyapunov(self.Ap.T, -self.Q)
 
+    def command(self):
+        raise NotImplementedError("method `command` not defined")
+
+    def step(self):
+        t = self.clock.get()
+        info = dict(t=t, **self.observe_dict())
+        *_, done = self.update()
+        next_obs = self.observe_list()
+        return next_obs, np.zeros(1), info, done
+
+
+class IndirectBacksteppingController(BacksteppingController):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
     def dynamics(self, xd, vd, ad, ad_dot, ad_ddot, Td_dot, xc):
         d_xd = vd
         d_vd = ad
@@ -91,14 +106,14 @@ class BacksteppingController(BaseEnv):
         ex = xd - pos
         ev = vd - vel
         ep = np.vstack((ex, ev))
+        Ap, Bp, P, Kp = self.Ap, self.Bp, self.P, self.Kp
         # u1
-        u1 = m * (ad - g) + self.Kp @ ep
+        u1 = m * (ad - g) + Kp @ ep
         zB = rot.T @ np.vstack((0, 0, 1))
         td = -Td * zB
         et = u1 - td
-        Ap, Bp, P = self.Ap, self.Bp, self.P
         ep_dot = Ap @ ep + Bp @ et
-        u1_dot = m * ad_dot + self.Kp @ ep_dot
+        u1_dot = m * ad_dot + Kp @ ep_dot
         T = Td  # TODO: no lag
         # u2
         u2 = T_u_inv(T[0]) @ rot @ (2*Bp.T @ P @ ep + u1_dot + self.Kt @ et)
@@ -107,7 +122,7 @@ class BacksteppingController(BaseEnv):
         zB_dot = -rot.T @ T_omega(1.0) @ omega
         et_dot = u1_dot + u2[-1] * zB + Td * zB_dot
         ep_ddot = Ap @ ep_dot + Bp @ et_dot
-        u1_ddot = m * ad_ddot + self.Kp @ ep_ddot
+        u1_ddot = m * ad_ddot + Kp @ ep_ddot
         rot_dot = -skew(omega) @ rot
         u2_dot = (
             (T_u_inv_dot(T[0], T_dot[0]) @ rot
@@ -126,12 +141,115 @@ class BacksteppingController(BaseEnv):
         nud = np.vstack((Td, Md))
         return nud, Td_dot
 
-    def step(self):
-        t = self.clock.get()
-        info = dict(t=t, **self.observe_dict())
-        *_, done = self.update()
-        next_obs = self.observe_list()
-        return next_obs, np.zeros(1), info, done
+
+class DirectBacksteppingController(BacksteppingController):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.Theta_hat = BaseSystem(np.zeros((6, 4)))
+        self.gamma = 1e5
+
+    def dynamics(self, xd, vd, ad, ad_dot, ad_ddot, Td_dot, Theta_hat_dot, xc):
+        d_xd = vd
+        d_vd = ad
+        d_ad = ad_dot
+        d_ad_dot = ad_ddot
+        d_ad_ddot = (-self.Kxd @ xd - self.Kvd @ vd - self.Kad @ ad
+                     - self.Kad_dot @ ad_dot - self.Kad_ddot @ ad_ddot + self.Kxd @ xc)
+        d_Td = Td_dot
+        d_Theta_hat = Theta_hat_dot
+        return d_xd, d_vd, d_ad, d_ad_dot, d_ad_ddot, d_Td, d_Theta_hat
+
+    def set_dot(self, Td_dot, Theta_hat_dot, xc):
+        xd, vd, ad, ad_dot, ad_ddot, *_ = self.observe_list()
+        self.xd.dot, self.vd.dot, self.ad.dot, self.ad_dot.dot, self.ad_ddot.dot, self.Td.dot, self.Theta_hat.dot = self.dynamics(xd, vd, ad, ad_dot, ad_ddot, Td_dot, Theta_hat_dot, xc)
+
+    # def Proj(self, theta, y, epsilon=1e-2, theta_max=1e5):
+    def Proj(self, theta, y, epsilon=1e-2, theta_max=1e5):
+        f = ((1+epsilon) * np.linalg.norm(theta)**2 - theta_max**2) / (epsilon * theta_max**2)
+        del_f = (2*(1+epsilon) / (epsilon * theta_max**2)) * theta  # nabla f
+        if f > 0 and del_f.T @ y > 0:
+            del_f_unit = del_f / np.linalg.norm(del_f)
+            proj = y - np.dot(del_f_unit, y) * f * del_f_unit
+        else:
+            proj = y
+        return proj
+
+    def Proj_R(self, C, Y):
+        proj_R = np.zeros(Y.shape)
+        for i in range(Y.shape[0]):
+            ci = C[i, :]
+            yi = Y[i, :]
+            proj_R[i, :] = self.Proj(ci, yi)
+        return proj_R
+
+    def command(self, pos, vel, quat, omega,
+                xd, vd, ad, ad_dot, ad_ddot, Td, Theta_hat,
+                m, J, g, B_A):
+        rot = quat2dcm(quat)
+        ex = xd - pos
+        ev = vd - vel
+        ep = np.vstack((ex, ev))
+        Ap, Bp, P, Kp = self.Ap, self.Bp, self.P, self.Kp
+        # u1
+        u1 = m * (ad - g) + Kp @ ep
+        zB = rot.T @ np.vstack((0, 0, 1))
+        td = -Td * zB
+        et = u1 - td
+        n_ep_dot = Ap @ ep + Bp @ et
+        n_u1_dot = m * ad_dot + Kp @ n_ep_dot
+        T = Td  # TODO: no lag
+        # u2
+        u2 = T_u_inv(T[0]) @ rot @ (2*Bp.T @ P @ ep + n_u1_dot + self.Kt @ et)
+        Td_dot = u2[-1]  # third element
+        T_dot = Td_dot  # TODO: no lag
+        zB_dot = -rot.T @ T_omega(1.0) @ omega
+        n_et_dot = n_u1_dot + u2[-1] * zB + Td * zB_dot
+        n_ep_ddot = Ap @ n_ep_dot + Bp @ n_et_dot
+        n_u1_ddot = m * ad_ddot + Kp @ n_ep_ddot
+        rot_dot = -skew(omega) @ rot
+        n_u2_dot = (
+            (T_u_inv_dot(T[0], T_dot[0]) @ rot
+             + T_u_inv(T[0]) @ rot_dot) @ (2*Bp.T @ P @ ep + n_u1_dot + self.Kt@et)
+            + (T_u_inv(T[0]) @ rot @ (2*Bp.T @ P @ n_ep_dot + n_u1_ddot + self.Kt @ n_et_dot))
+        )
+        n_omegad_dot = np.array([[1, 0, 0],
+                                 [0, 1, 0],
+                                 [0, 0, 0]]) @ n_u2_dot
+        omegad = np.vstack((u2[:2], 0))
+        eomega = omegad - omega
+        # Md
+        Md = (
+            np.cross(omega, J@omega, axis=0)
+            + J @ (T_omega(T[0]).T @ rot @ et + n_omegad_dot + self.Komega @ eomega)
+        )
+        # nud
+        nud = np.vstack((Td, Md))
+        # Theta_hat_dot
+        e = np.vstack((ep, et, eomega))
+        P_bar = np.block([
+            [P, np.zeros((6, 6))],
+            [np.zeros((6, 6)), 0.5*np.eye(6)]
+        ])
+        theta_ep_dot = Bp
+        theta_u1_dot = Kp @ theta_ep_dot
+        theta_et_dot = theta_u1_dot
+        theta_ep_ddot = Ap @ theta_ep_dot + Bp @ theta_et_dot
+        theta_u1_ddot = Kp @ theta_ep_ddot
+        theta_u2_dot = T_u_inv(T[0]) @ rot @ (2*Bp.T @ P @ theta_ep_dot
+                                              + theta_u1_ddot + self.Kt @ theta_et_dot)
+        theta_omegad_dot = np.array([[1, 0, 0],
+                                     [0, 1, 0],
+                                     [0, 0, 0]]) @ theta_u2_dot
+        B_bar = np.block([
+            [-theta_ep_dot @ zB, np.zeros((6, 3))],
+            [-theta_u1_dot @ zB, np.zeros((3, 3))],
+            [-theta_omegad_dot @ zB, np.linalg.inv(J)]
+        ])
+        Theta_hat_dot = self.gamma * self.Proj_R(
+            Theta_hat, (nud @ e.T @ P_bar @ B_bar @ B_A).T
+        )
+        import ipdb; ipdb.set_trace()
+        return nud, Td_dot, Theta_hat_dot
 
 
 if __name__ == "__main__":

--- a/ftc/agents/backstepping.py
+++ b/ftc/agents/backstepping.py
@@ -146,7 +146,7 @@ class DirectBacksteppingController(BacksteppingController):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.Theta_hat = BaseSystem(np.zeros((6, 4)))
-        self.gamma = 1e5
+        self.gamma = 1e8
 
     def dynamics(self, xd, vd, ad, ad_dot, ad_ddot, Td_dot, Theta_hat_dot, xc):
         d_xd = vd
@@ -208,8 +208,8 @@ class DirectBacksteppingController(BacksteppingController):
         n_u1_ddot = m * ad_ddot + Kp @ n_ep_ddot
         rot_dot = -skew(omega) @ rot
         n_u2_dot = (
-            (T_u_inv_dot(T[0], T_dot[0]) @ rot
-             + T_u_inv(T[0]) @ rot_dot) @ (2*Bp.T @ P @ ep + n_u1_dot + self.Kt@et)
+            (T_u_inv_dot(T[0], T_dot[0]) @ rot + T_u_inv(T[0]) @ rot_dot)
+            @ (2*Bp.T @ P @ ep + n_u1_dot + self.Kt@et)
             + (T_u_inv(T[0]) @ rot @ (2*Bp.T @ P @ n_ep_dot + n_u1_ddot + self.Kt @ n_et_dot))
         )
         n_omegad_dot = np.array([[1, 0, 0],
@@ -248,7 +248,6 @@ class DirectBacksteppingController(BacksteppingController):
         Theta_hat_dot = self.gamma * self.Proj_R(
             Theta_hat, (nud @ e.T @ P_bar @ B_bar @ B_A).T
         )
-        import ipdb; ipdb.set_trace()
         return nud, Td_dot, Theta_hat_dot
 
 

--- a/ftc/agents/backstepping.py
+++ b/ftc/agents/backstepping.py
@@ -146,7 +146,8 @@ class DirectBacksteppingController(BacksteppingController):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.Theta_hat = BaseSystem(np.zeros((6, 4)))
-        self.gamma = 1e8
+        self.gamma = 1e0
+        # self.gamma = 1e8  # for falconi hexacopter model
 
     def dynamics(self, xd, vd, ad, ad_dot, ad_ddot, Td_dot, Theta_hat_dot, xc):
         d_xd = vd

--- a/ftc/models/multicopter.py
+++ b/ftc/models/multicopter.py
@@ -134,7 +134,7 @@ class Multicopter(BaseEnv):
                  vel=np.zeros((3, 1)),
                  quat=np.vstack((1, 0, 0, 0)),
                  omega=np.zeros((3, 1)),
-                 rtype="hexa-x"):
+                 rtype="hexa-falconi"):
         super().__init__()
         self.pos = BaseSystem(pos)
         self.vel = BaseSystem(vel)

--- a/ftc/models/multicopter.py
+++ b/ftc/models/multicopter.py
@@ -74,7 +74,7 @@ class Mixer:
 
 
 class Multicopter(BaseEnv):
-    model = "taeyoung_lee"
+    model = "falconi"
     if model == "taeyoung_lee":
         """Reference:
         [1] Prof. Taeyoung Lee's model for quadrotor UAV is used.

--- a/ftc/models/multicopter.py
+++ b/ftc/models/multicopter.py
@@ -74,7 +74,7 @@ class Mixer:
 
 
 class Multicopter(BaseEnv):
-    model = "falconi"
+    model = "taeyoung_lee"
     if model == "taeyoung_lee":
         """Reference:
         [1] Prof. Taeyoung Lee's model for quadrotor UAV is used.
@@ -134,7 +134,7 @@ class Multicopter(BaseEnv):
                  vel=np.zeros((3, 1)),
                  quat=np.vstack((1, 0, 0, 0)),
                  omega=np.zeros((3, 1)),
-                 rtype="hexa-falconi"):
+                 rtype="hexa-x"):
         super().__init__()
         self.pos = BaseSystem(pos)
         self.vel = BaseSystem(vel)

--- a/test/backstepping.py
+++ b/test/backstepping.py
@@ -167,6 +167,11 @@ def run(method):
         done = env.step()
 
         if done:
+            env_info = {
+                "rotor_min": env.plant.rotor_min,
+                "rotor_max": env.plant.rotor_max,
+            }
+            env.logger.set_info(**env_info)
             break
 
     env.close()
@@ -177,7 +182,7 @@ def exp_indirect():
 
 
 def exp_indirect_plot():
-    data = fym.logging.load("data.h5")
+    data, info = fym.logging.load("data.h5", with_info=True)
 
     plt.figure()
     plt.plot(data["t"], data["x"]["pos"][:, :, 0], "r--", label="pos")  # position
@@ -192,16 +197,25 @@ def exp_direct():
 
 
 def exp_direct_plot():
-    data = fym.logging.load("data.h5")
-
+    data, info = fym.logging.load("data.h5", with_info=True)
+    # position
     plt.figure()
+    plt.title("position")
     plt.plot(data["t"], data["x"]["pos"][:, :, 0], "r--", label="pos")  # position
     plt.plot(data["t"], data["pos_c"][:, :, 0], "k--", label="position command")  # position command
-
     plt.legend()
     plt.savefig("position.png")
-
+    # rotor
     plt.figure()
+    plt.ylim([info["rotor_min"], info["rotor_max"]])
+    plt.title("rotor input")
+    for i in range(data["u"].shape[1]):
+        plt.plot(data["t"], data["u"][:, i, 0], label=f"u_{i}")
+    plt.legend()
+    plt.savefig("rotor_input.png")
+    # Euler angles
+    plt.figure()
+    plt.title("Euler angles")
     plt.ylabel("Euler angles (deg)")
     _shape = data["x"]["quat"][:, :, 0].shape
     angles = np.zeros((_shape[0], 3))

--- a/test/backstepping.py
+++ b/test/backstepping.py
@@ -55,9 +55,8 @@ class Env(BaseEnv):
         # Define faults
         self.sensor_faults = []
         self.actuator_faults = [
-            LoE(time=3, index=0, level=0.5),
-            LoE(time=5, index=1, level=0.2),
-            LoE(time=7, index=2, level=0.5),
+            LoE(time=3, index=0, level=0.0),
+            LoE(time=5, index=1, level=0.0),
             # Float(time=10, index=0),
         ]
 
@@ -104,14 +103,15 @@ class Env(BaseEnv):
                 *self.plant.observe_list(), *self.controller.observe_list(),
                 self.plant.m, self.plant.J, np.vstack((0, 0, self.plant.g)),
             )
-            u = u_command = self.control_allocation(FM, What)
+            u_command = self.control_allocation(FM, What)
         elif self.method == "direct":
             FM, Td_dot, Theta_hat_dot = self.controller.command(
                 *self.plant.observe_list(), *self.controller.observe_list(),
                 self.plant.m, self.plant.J, np.vstack((0, 0, self.plant.g)), self.plant.mixer.B,
             )
             Theta_hat = self.controller.Theta_hat.state
-            u = u_command = (self.plant.mixer.Binv + Theta_hat) @ FM
+            u_command = (self.plant.mixer.Binv + Theta_hat) @ FM
+        u = np.clip(u_command, self.plant.rotor_min, self.plant.rotor_max)
 
         # Set actuator faults
         for act_fault in self.actuator_faults:

--- a/test/backstepping.py
+++ b/test/backstepping.py
@@ -55,9 +55,9 @@ class Env(BaseEnv):
         # Define faults
         self.sensor_faults = []
         self.actuator_faults = [
-            # LoE(time=3, index=0, level=0.5),
-            # LoE(time=5, index=1, level=0.2),
-            # LoE(time=7, index=2, level=0.5),
+            LoE(time=3, index=0, level=0.5),
+            LoE(time=5, index=1, level=0.2),
+            LoE(time=7, index=2, level=0.5),
             # Float(time=10, index=0),
         ]
 
@@ -112,9 +112,6 @@ class Env(BaseEnv):
             )
             Theta_hat = self.controller.Theta_hat.state
             u = u_command = (self.plant.mixer.Binv + Theta_hat) @ FM
-            # import ipdb; ipdb.set_trace()
-            # u_command = (self.plant.mixer.Binv + Theta_hat) @ FM
-            # u = np.clip(u_command, 0, 2/6*9.8*self.plant.m/self.plant.b)  # TODO
 
         # Set actuator faults
         for act_fault in self.actuator_faults:

--- a/test/backstepping.py
+++ b/test/backstepping.py
@@ -2,7 +2,7 @@ import numpy as np
 import matplotlib.pyplot as plt
 
 from fym.core import BaseEnv, BaseSystem
-from fym.utils.rot import angle2quat
+from fym.utils.rot import angle2quat, quat2angle
 import fym.logging
 
 from ftc.models.multicopter import Multicopter
@@ -197,10 +197,22 @@ def exp_direct_plot():
     plt.figure()
     plt.plot(data["t"], data["x"]["pos"][:, :, 0], "r--", label="pos")  # position
     plt.plot(data["t"], data["pos_c"][:, :, 0], "k--", label="position command")  # position command
-    # plt.plot(data["t"], data["Theta_hat_dot"][:, :, 0], "g--", label="adaptive parameter")  # position command
 
     plt.legend()
-    plt.show()
+    plt.savefig("position.png")
+
+    plt.figure()
+    plt.ylabel("Euler angles (deg)")
+    _shape = data["x"]["quat"][:, :, 0].shape
+    angles = np.zeros((_shape[0], 3))
+    for i in range(_shape[0]):
+        _angle = quat2angle(data["x"]["quat"][i, :, 0])
+        angles[i, :] = _angle
+    plt.plot(data["t"], np.rad2deg(angles[:, 0]), "r--", label="yaw")
+    plt.plot(data["t"], np.rad2deg(angles[:, 1]), "g--", label="pitch")
+    plt.plot(data["t"], np.rad2deg(angles[:, 2]), "b--", label="roll")
+    plt.legend()
+    plt.savefig("angles.png")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Resolve #28.

# Summary
## Class structure
- Direct/indirect backstepping controllers 는 둘 다 `BacksteppingController` 라는 클래스를 상속받음 (각각 `{Direct,Indirect}BacksteppingController`).
## Test files
- Direct backstepping controller 를 설계함. `test/backstepping.py` 에서 `exp_direct` 와 `exp_indirect` 로 direct / indirect 비교 가능.
### 예시 결과
- 적용된 faults
```python3
        # Define faults
        self.sensor_faults = []
        self.actuator_faults = [
            LoE(time=3, index=0, level=0.5),
            LoE(time=5, index=1, level=0.2),
            LoE(time=7, index=2, level=0.5),
            # Float(time=10, index=0),
        ]
```
- 그래프 (set-point position regulation)
![image](https://user-images.githubusercontent.com/43136096/119298455-0c290d80-bc98-11eb-8fc2-6d867c00cccd.png)


# Notes
## Parameters
- `gamma` 는 적응 게인.
    - `taeyoung_lee` + `hexa-x` 에서 `gamma=1e0` 으로 검증됨 (65d94c1)
    - `falconi` + `hexa-falconi` 에서 `gamma=1e8` 로 검증됨 (71b165a)
## Issues
- ~~계속 발산하는 이슈가 있었음~~ 각 헥사콥터 모델별로 파라미터가 크게 달라서 생긴 문제였음.