### PR TITLE
Add calculate_recovery_rate

### DIFF
--- a/ftc/evaluate/evaluate.py
+++ b/ftc/evaluate/evaluate.py
@@ -3,7 +3,7 @@ import numpy as np
 
 def calculate_recovery_rate(errors: np.ndarray, threshold: float=0.5):
     assert threshold > 0
-    recovery_rate = np.average(errors <= threshold)
+    recovery_rate = np.average(np.abs(errors) <= threshold)
     return recovery_rate
 
 

--- a/ftc/evaluate/evaluate.py
+++ b/ftc/evaluate/evaluate.py
@@ -1,0 +1,21 @@
+import numpy as np
+
+
+def calculate_recovery_rate(errors: np.ndarray, threshold: float=0.5):
+    assert threshold > 0
+    is_success_array = np.zeros_like(errors)
+    for i, error in enumerate(errors):
+        is_success_array[i] = abs(error) <= threshold  # the absolute value of error
+    recovery_rate = np.sum(is_success_array) / np.prod(is_success_array.shape)
+    return recovery_rate
+
+
+if __name__ == "__main__":
+    errors = np.array([
+        [1, 2],
+        [2, 3],
+        [0, 1],
+    ])
+    threshold = 1.0
+    recovery_rate = calculate_recovery_rate(errors, threshold=threshold)
+    print(recovery_rate)

--- a/ftc/evaluate/evaluate.py
+++ b/ftc/evaluate/evaluate.py
@@ -3,10 +3,7 @@ import numpy as np
 
 def calculate_recovery_rate(errors: np.ndarray, threshold: float=0.5):
     assert threshold > 0
-    is_success_array = np.zeros_like(errors)
-    for i, error in enumerate(errors):
-        is_success_array[i] = abs(error) <= threshold  # the absolute value of error
-    recovery_rate = np.sum(is_success_array) / np.prod(is_success_array.shape)
+    recovery_rate = np.average(errors <= threshold)
     return recovery_rate
 
 

--- a/ftc/evaluate/evaluate.py
+++ b/ftc/evaluate/evaluate.py
@@ -12,7 +12,7 @@ def calculate_recovery_rate(errors: np.ndarray, threshold: float=0.5):
 
 if __name__ == "__main__":
     errors = np.array([
-        [1, 2],
+        [-1, 2],
         [2, 3],
         [0, 1],
     ])


### PR DESCRIPTION
Resolve #74.

회복률 계산 함수를 작성함.
- 아무 형태의 np.ndarray 를 받아서, 각 원소의 절대값이 주어진 `threshold > 0` 보다 작거나 같으면 성공으로 취급

- See `ftc/evaluate/evaluate.py`.
- Code example
```python3
    errors = np.array([
        [-1, 2],
        [2, 3],
        [0, 1],
    ])
    threshold = 1.0
    recovery_rate = calculate_recovery_rate(errors, threshold=threshold)
    print(recovery_rate)
```
- Result
```
0.5
```