### PR TITLE
Modify scenario_a_3 to meet the new Fym version

### DIFF
--- a/ftc/agents/backstepping.py
+++ b/ftc/agents/backstepping.py
@@ -145,7 +145,7 @@ class IndirectBacksteppingController(BacksteppingController):
 class DirectBacksteppingController(BacksteppingController):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        self.Theta_hat = BaseSystem(np.zeros((6, 4)))
+        self.Theta_hat = BaseSystem(shape=(6, 4))
         self.gamma = 1e-1
         # self.gamma = 1e-0  # for taeyoung_lee hexacopter model with hexa-x
         # self.gamma = 1e8  # for falconi hexacopter model


### PR DESCRIPTION
새로운 Fym 버전에 맞게 `scenario_a_3.py`를 좀 바꿨습니다.

그런데.. 솔버를 RK4 (dt=0.01) 를 사용했을때와 variable-step `odeint`를 사용했을 때 결과 차이가 많이 나는군요..
비선형 제어기를 적용할 때에는 생각치 못하게 큰 제어입력 미분치가 들어올 수 있으니 variable-step 솔버를 일단 사용하고, 후에 rk7~8 정도의 고정밀 솔버 + 매우 작은 dt로 비교해서 분석해야 할 것 같습니다.
<img width="752" alt="image" src="https://user-images.githubusercontent.com/9782545/122855376-2239f480-d350-11eb-9daa-e6611472514e.png">
<img width="752" alt="image" src="https://user-images.githubusercontent.com/9782545/122855396-2a922f80-d350-11eb-968b-a31717ea36f7.png">
<img width="752" alt="image" src="https://user-images.githubusercontent.com/9782545/122855385-27973f00-d350-11eb-99e6-91012702e1b8.png">
<img width="752" alt="image" src="https://user-images.githubusercontent.com/9782545/122855408-2d8d2000-d350-11eb-881d-f6fcc6c58547.png">
<img width="752" alt="image" src="https://user-images.githubusercontent.com/9782545/122855427-35e55b00-d350-11eb-8b92-5654430e9e3c.png">

