### PR TITLE
FDI 모듈 수정

### DIFF
--- a/ftc/agents/fdi.py
+++ b/ftc/agents/fdi.py
@@ -1,17 +1,27 @@
 import numpy as np
 from numpy import searchsorted as ss
+from functools import reduce
+
 from fym.core import BaseEnv, BaseSystem
+
+
+def get_loe(actuator_faults, no_act):
+    actuator_faults = sorted(actuator_faults, key=lambda x: x.time)
+    loe = np.eye(no_act)
+    yield loe
+    for act_fault in actuator_faults:
+        loe = loe.copy()
+        loe[act_fault.index, act_fault.index] = act_fault.level
+        yield loe
 
 
 class SimpleFDI():
     def __init__(self, actuator_faults, no_act, delay=0.):
         self.delay = delay
-        self.loe = [
-            np.eye(no_act),
-            *map(lambda x: x.level * np.eye(no_act),
-                 sorted(actuator_faults, key=lambda x: x.time))
-        ]
-        self.fault_times = np.array([0] + [x.time for x in actuator_faults])
+
+        self.loe = list(get_loe(actuator_faults, no_act))
+        self.fault_times = np.array(
+            [0] + sorted([x.time for x in actuator_faults]))
 
     def get(self, t):
         index = max(ss(self.fault_times, t - self.delay, side="right") - 1, 0)
@@ -20,3 +30,14 @@ class SimpleFDI():
     def get_real(self, t):
         index = ss(self.fault_times, t, side="right") - 1
         return self.loe[index]
+
+
+if __name__ == "__main__":
+    from ftc.faults.actuator import LoE, LiP, Float
+
+    actuator_faults = [
+        LoE(time=3, index=0, level=0.7),
+        LoE(time=6, index=2, level=0.8),
+        LoE(time=1, index=0, level=0.6),
+    ]
+    fdi = SimpleFDI(actuator_faults, 6)

--- a/ftc/agents/fdi.py
+++ b/ftc/agents/fdi.py
@@ -16,8 +16,9 @@ def get_loe(actuator_faults, no_act):
 
 
 class SimpleFDI():
-    def __init__(self, actuator_faults, no_act, delay=0.):
+    def __init__(self, actuator_faults, no_act, delay=0., threshold=0.):
         self.delay = delay
+        self.threshold = threshold
 
         self.loe = list(get_loe(actuator_faults, no_act))
         self.fault_times = np.array(
@@ -30,6 +31,9 @@ class SimpleFDI():
     def get_real(self, t):
         index = ss(self.fault_times, t, side="right") - 1
         return self.loe[index]
+
+    def get_index(self, t):
+        return np.nonzero(np.diag(self.get(t)) < 1 - self.threshold)[0]
 
 
 if __name__ == "__main__":

--- a/ftc/agents/fdi.py
+++ b/ftc/agents/fdi.py
@@ -28,7 +28,7 @@ class SimpleFDI():
         index = max(ss(self.fault_times, t - self.delay, side="right") - 1, 0)
         return self.loe[index]
 
-    def get_real(self, t):
+    def get_true(self, t):
         index = ss(self.fault_times, t, side="right") - 1
         return self.loe[index]
 

--- a/ftc/faults/actuator.py
+++ b/ftc/faults/actuator.py
@@ -9,15 +9,28 @@ class Fault:
 
     The base class of fault models.
     """
+    count = 0
+    num = 0
+
     def __init__(self, time=0, index=0, name=None):
         self.time = time
         self.index = index
         self.name = name
+        Fault.num += 1
 
     def __repr__(self):
         return f"Fault name: {self.name}" + "\n" + f"time = {self.time}, index = {self.index}"
 
     def __call__(self, *args, **kwargs):
+        if Fault.count == 0:
+            Fault.args = args
+            Fault.kwargs = kwargs
+        else:
+            args = Fault.args
+            kwargs = Fault.kwargs
+        Fault.count += 1
+        if Fault.count == Fault.num:
+            Fault.count = 0
         return self.get(*args, **kwargs)
 
     def get(t, u):


### PR DESCRIPTION
Resolves #85 #80 #76 

FDI 모듈을 LPF 형태가 아닌 시간에 대한 함수 꼴로 delay를 두고 나오도록 변경했습니다(#80, #85).
Fault 모델은 그대로 사용이 가능하며, SimpleFDI의 사용법만 바뀌었습니다.

또한, #76 에서 논의된 바와 같이 곱해지는 방식이 아닌, LoE가 덮어씌워지는 방식으로 변경했습니다.
	
## Instantiation
```python
actuator_faults = [
    LoE(time=3, index=0, level=0.7),
    LoE(time=5, index=0, level=0.5),
    LoE(time=2, index=1, level=0.8),
    LoE(time=7, index=1, level=0.2)
]
fdi = SimpleFDI(actuator_faults, no_act=6, delay=0.2, threshold=0.1)
```

## Usage
```python
fault_index = fdi.get_index(t)
What = fdi.get(t)
W = fdi.get_true(t)
```