### PR TITLE
Add modularized main

### DIFF
--- a/ftc/agents/lqr.py
+++ b/ftc/agents/lqr.py
@@ -8,12 +8,15 @@ from ftc.models.multicopter import Multicopter
 import fym.logging
 from fym.core import BaseEnv, BaseSystem
 
+import ftc.config
+
+cfg = ftc.config.load(__name__)
+
 
 class LQRController:
-    def __init__(self, Jinv, m, g,
-                 Q=np.diag([1, 1, 1, 0, 0, 0, 1, 1, 1, 0, 0, 0]),
-                 R=np.diag([1, 1, 1, 1]),
-                 ):
+    def __init__(self, Jinv, m, g):
+        Q = cfg.LQRGain.Q
+        R = cfg.LQRGain.R
         self.Jinv = Jinv
         self.m, self.g = m, g
         self.trim_forces = np.vstack([self.m * self.g, 0, 0, 0])

--- a/ftc/config.py
+++ b/ftc/config.py
@@ -25,6 +25,15 @@ default_settings = fym.parser.parse({
 
     # ====== ftc.agents ====== #
 
+    # ------ ftc.agents.lqr ------ #
+
+    "agents.lqr": {
+        "LQRGain": {
+            "Q": np.diag([1, 1, 1, 0, 0, 0, 1, 1, 1, 0, 0, 0]),
+            "R": np.diag([1, 1, 1, 1]),
+        },
+    },
+
     # ------ ftc.agents.switcing_lqr ------ #
 
     "agents.switching_lqr": {


### PR DESCRIPTION
모듈화된 스크립트 작성을 위해 `ftc`모듈을 조금 수정함.
- `config`에 lqr 제어기 게인 추가
- `ftc-simscripts` [PR 22](https://github.com/fdcl-ftc/ftc-simscripts/pull/22)와 함께 실행