### PR TITLE
Fix ftc.make method

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,12 +35,25 @@ As you may notice, this registration process is borrowed from the OpenAI Gym mod
 ### Make a Controller Instance
 
 After the controller is registered, one can make an instance of the controller class by `ftc.make` method.
+The `env` keyword in the `ftc.make` method would be used to initialize each controller.
 
 ```python
-controller = ftc.make("My-SMC-v1")
+controller = ftc.make("My-SMC-v1", env=env)
 ```
 
 ## Controller Class API
+
+### Initialize
+
+Controllers often require some information of the plant and/or the environement *a priori*.
+For example, linearized state-space system matrices is necessary to design an LQR.
+For ease of integrated simulation, each controller class must be initialized with the argument ``env`` as follows.
+
+```python
+class MyController:
+    def __init__(self, env):
+        ...
+```
 
 ### `get_control` Method
 

--- a/examples/sample_controller_dsc.py
+++ b/examples/sample_controller_dsc.py
@@ -186,7 +186,7 @@ class ExtendedQuadEnv(fym.BaseEnv):
         # quad
         self.plant = Quad(env_config["quad"])
         # controller
-        self.controller = ftc.make("PPC-DSC")
+        self.controller = ftc.make("PPC-DSC", self)
 
     def step(self, action):
         obs = self.observation()

--- a/ftc/controllers/PPC-DSC/ppcdsc.py
+++ b/ftc/controllers/PPC-DSC/ppcdsc.py
@@ -13,7 +13,7 @@ def get_angles(R):
 
 
 class DSCController(fym.BaseEnv):
-    def __init__(self):
+    def __init__(self, env):
         super().__init__()
         # filters
         self.filter_vd = fym.BaseSystem(0.000 * np.ones((3, 1)))

--- a/ftc/registration.py
+++ b/ftc/registration.py
@@ -1,6 +1,5 @@
 import importlib
 
-
 registry = {}
 
 

--- a/ftc/utils.py
+++ b/ftc/utils.py
@@ -1,8 +1,8 @@
 from ftc.registration import registry
 
 
-def make(id):
-    return registry[id]()
+def make(id, env):
+    return registry[id](env)
 
 
 def get_controllers(*args):

--- a/ftc/utils.py
+++ b/ftc/utils.py
@@ -1,13 +1,15 @@
 from ftc.registration import registry
 
 
-def make(id, env):
+def make(id, env=None):
+    assert env is not None
     return registry[id](env)
 
 
-def get_controllers(*args):
+def get_controllers(*args, env=None):
+    assert env is not None
     controllers = []
     for id in args:
-        controllers.append(make(id))
+        controllers.append(make(id, env=env))
 
     return controllers or [Controller() for Controller in registry.values()]


### PR DESCRIPTION
`ftc.make` method가 추가적으로 `env` 인자를 받도록 수정